### PR TITLE
Remove accommodation & meals selection from convention registration

### DIFF
--- a/app/convention/register/form.tsx
+++ b/app/convention/register/form.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { useForm, useFieldArray } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
-import { CalendarFold, MapPin, Coffee, Plus, Loader2, ArrowUpRight, BedDouble, UtensilsCrossed } from "lucide-react";
+import { CalendarFold, MapPin, Coffee, Plus, Loader2, ArrowUpRight } from "lucide-react";
 import { CONVENTION_2026 } from "@/data/convention";
 import { toast } from "@/components/hooks/use-toast";
 import { Button } from "@/components/ui/button";
@@ -49,8 +49,6 @@ export function ConventionRegistrationForm() {
             attendees: [{ ...defaultAttendee }],
             email: "",
             newsletterOptIn: false,
-            interestedInAccommodation: false,
-            interestedInMeals: false,
             privacyPolicyAccepted: false as unknown as true,
         },
     });
@@ -247,97 +245,6 @@ export function ConventionRegistrationForm() {
                                 </FormItem>
                             )}
                         />
-                    </div>
-                </div>
-
-                {/* Accommodation & Meals */}
-                <div>
-                    <h1 className="text-asi-blue text-left text-lg font-bold md:text-xl mb-4">
-                        Accommodation & Meals
-                    </h1>
-                    <p className="text-gray-600 text-sm mb-6">
-                        These options do not affect your registration price. We&apos;ll send booking details separately after registration.
-                    </p>
-
-                    <div className="space-y-4">
-                        <div className="bg-white p-5 rounded-2xl space-y-4">
-                            <div className="flex items-start gap-3">
-                                <div className="rounded-xl bg-asi-blue/10 p-2.5 text-asi-blue mt-0.5">
-                                    <BedDouble className="h-5 w-5" />
-                                </div>
-                                <div>
-                                    <h2 className="font-medium text-asi-blue text-base">On-campus Accommodation</h2>
-                                    <p className="text-sm text-gray-600 mt-1">
-                                        On-campus rooms are available for convention attendees, starting from £41 per night.
-                                        Options range from shared-standard rooms and bunk rooms through to en-suite singles and doubles,
-                                        across Keough House, Schuil House, and Moor Close. Self-catering flats are also available.
-                                    </p>
-                                    <p className="text-sm text-gray-500 mt-2">
-                                        <span className="font-medium">Indicative nightly rates:</span>{" "}
-                                        Singles from £41 · Doubles from £53 · En-suite singles £53 · En-suite doubles £79 · Bunk beds from £22pp · Flats from £126
-                                    </p>
-                                </div>
-                            </div>
-
-                            <FormField
-                                control={form.control}
-                                name="interestedInAccommodation"
-                                render={({ field }) => (
-                                    <FormItem className="flex flex-row items-start space-x-3 space-y-0 pl-12">
-                                        <FormControl>
-                                            <Checkbox
-                                                checked={field.value}
-                                                onCheckedChange={field.onChange}
-                                            />
-                                        </FormControl>
-                                        <div className="space-y-1 leading-none">
-                                            <FormLabel className="font-normal">
-                                                Yes, please send me accommodation booking details
-                                            </FormLabel>
-                                        </div>
-                                    </FormItem>
-                                )}
-                            />
-                        </div>
-
-                        <div className="bg-white p-5 rounded-2xl space-y-4">
-                            <div className="flex items-start gap-3">
-                                <div className="rounded-xl bg-asi-blue/10 p-2.5 text-asi-blue mt-0.5">
-                                    <UtensilsCrossed className="h-5 w-5" />
-                                </div>
-                                <div>
-                                    <h2 className="font-medium text-asi-blue text-base">Meals</h2>
-                                    <p className="text-sm text-gray-600 mt-1">
-                                        Light refreshments are included with your registration throughout the convention.
-                                        Full meals in the Newbold dining hall are also available for booking, alongside your accommodation or on their own.
-                                    </p>
-                                    <p className="text-sm text-gray-500 mt-2">
-                                        <span className="font-medium">Per meal:</span>{" "}
-                                        Breakfast £7.80 (under-12s £4.40) · Lunch or dinner £9.31 (under-12s £6.00)
-                                    </p>
-                                </div>
-                            </div>
-
-                            <FormField
-                                control={form.control}
-                                name="interestedInMeals"
-                                render={({ field }) => (
-                                    <FormItem className="flex flex-row items-start space-x-3 space-y-0 pl-12">
-                                        <FormControl>
-                                            <Checkbox
-                                                checked={field.value}
-                                                onCheckedChange={field.onChange}
-                                            />
-                                        </FormControl>
-                                        <div className="space-y-1 leading-none">
-                                            <FormLabel className="font-normal">
-                                                Yes, please send me meal booking details
-                                            </FormLabel>
-                                        </div>
-                                    </FormItem>
-                                )}
-                            />
-                        </div>
                     </div>
                 </div>
 

--- a/data/convention.ts
+++ b/data/convention.ts
@@ -88,7 +88,7 @@ export const CONVENTION_2026 = {
         },
         {
             question: "Is accommodation available?",
-            answer: "Yes — on-campus rooms are available at Newbold College, starting from £41 per night. Options range from shared-standard rooms and bunk rooms to en-suite singles and doubles, plus self-catering flats. You can indicate your interest during registration and we'll send you booking details.",
+            answer: "On-campus rooms at Newbold College were available to book alongside convention registration until 15 June 2026. Unfortunately, we are unable to accept bookings for accommodation at Newbold after this date.",
         },
         {
             question: "Is parking available?",
@@ -96,7 +96,7 @@ export const CONVENTION_2026 = {
         },
         {
             question: "What's included with my ticket?",
-            answer: "Light refreshments throughout each day are included with your registration. Full meals in the Newbold dining hall are also available for booking — breakfast £7.80, lunch or dinner £9.31 (reduced rates for under-12s). You can indicate your interest during registration and we'll send you booking details.",
+            answer: "Light refreshments throughout each day are included with your registration. Cafeteria meals in the Newbold dining hall were available to book alongside convention registration until 15 June 2026. Unfortunately, we are unable to accept bookings for cafeteria meals at Newbold after this date.",
         },
         {
             question: "How do I qualify for the member discount?",

--- a/lib/notion-convention.ts
+++ b/lib/notion-convention.ts
@@ -190,8 +190,8 @@ export async function createConventionRegistration(
             Status: { select: { name: status } },
             "Registration Date": { date: { start: new Date().toISOString() } },
             "Newsletter Opt-in": { checkbox: data.newsletterOptIn },
-            "Interested in Newbold Accommodations": { checkbox: data.interestedInAccommodation },
-            "Interested in Newbold Meals": { checkbox: data.interestedInMeals },
+            "Interested in Newbold Accommodations": { checkbox: false },
+            "Interested in Newbold Meals": { checkbox: false },
         };
 
         // Get data source ID for the registrations database

--- a/lib/schemas/convention-registration.ts
+++ b/lib/schemas/convention-registration.ts
@@ -61,8 +61,6 @@ export const conventionRegistrationSchema = z.object({
         .max(100, "Email must not exceed 100 characters")
         .regex(emailPattern, "Please enter a valid email address"),
     newsletterOptIn: z.boolean().optional().default(false),
-    interestedInAccommodation: z.boolean().optional().default(false),
-    interestedInMeals: z.boolean().optional().default(false),
     privacyPolicyAccepted: z.literal(true, {
         errorMap: () => ({ message: "You must accept the privacy policy to continue" }),
     }),
@@ -122,8 +120,6 @@ export interface ConventionRegistrationServiceData {
     attendees: AttendeeData[];
     email: string;
     newsletterOptIn: boolean;
-    interestedInAccommodation: boolean;
-    interestedInMeals: boolean;
     privacyPolicyAccepted: boolean;
     orderTotal: number;
     attendeeCount: number;
@@ -144,8 +140,6 @@ export function toServiceData(data: ConventionRegistrationData): ConventionRegis
         attendees: data.attendees,
         email: data.email,
         newsletterOptIn: data.newsletterOptIn ?? false,
-        interestedInAccommodation: data.interestedInAccommodation ?? false,
-        interestedInMeals: data.interestedInMeals ?? false,
         privacyPolicyAccepted: data.privacyPolicyAccepted,
         orderTotal: calculateOrderTotal(data.attendees),
         attendeeCount: data.attendees.length,


### PR DESCRIPTION
Bookings for on-campus accommodation and cafeteria meals at Newbold can no longer be accepted so close to the convention. Removes the "Accommodation & Meals" interest section and its two checkboxes from the registration form and schema.

The Notion Registrations database is left unchanged to retain values from earlier submissions, so the "Interested in Newbold Accommodations/Meals" checkbox properties are still posted, now hardcoded to false. Updates the accommodation and meals FAQ answers to note bookings closed after 15 June.