### PR TITLE
Show pledged funding as stacked segment on progress bar

### DIFF
--- a/app/components/ProgressBar.tsx
+++ b/app/components/ProgressBar.tsx
@@ -1,6 +1,8 @@
 interface ProgressBarProps {
     current: number;
     total: number;
+    // Additional amount pledged but not yet received. Rendered as a distinct
+    // segment stacked on top of the received bar (i.e. received + pledged).
     pledged?: number;
     className?: string;
     variant?: 'default' | 'light';
@@ -9,7 +11,11 @@ interface ProgressBarProps {
 export default function ProgressBar({ current, total, pledged, className = "", variant = "default" }: ProgressBarProps) {
     const percentage = total > 0 ? Math.min((current / total) * 100, 100) : 0;
     const hasPledged = pledged != null && pledged > 0;
-    const pledgedPercentage = hasPledged ? Math.min((pledged / total) * 100, 100) : 0;
+    // Stack the pledged segment after the received bar, capped so the two
+    // together never exceed the full track width.
+    const pledgedPercentage = hasPledged && total > 0
+        ? Math.min((pledged / total) * 100, 100 - percentage)
+        : 0;
     const isLight = variant === 'light';
 
     return (
@@ -20,17 +26,17 @@ export default function ProgressBar({ current, total, pledged, className = "", v
                     £{current.toLocaleString()}{hasPledged ? ' received' : ''} of £{total.toLocaleString()}
                 </span>
             </div>
-            <div className={`relative w-full rounded-full h-4 overflow-hidden ${isLight ? 'bg-white/20' : 'bg-slate-200'}`}>
+            <div className={`relative flex w-full rounded-full h-4 overflow-hidden ${isLight ? 'bg-white/20' : 'bg-slate-200'}`}>
+                <div
+                    className={`h-full transition-all duration-500 ease-out ${isLight ? 'bg-white' : 'bg-gradient-to-r from-asi-blue to-asi-darkBlue'}`}
+                    style={{ width: `${percentage}%` }}
+                />
                 {hasPledged && (
                     <div
-                        className={`absolute h-full rounded-full ${isLight ? 'bg-white/40' : 'bg-asi-blue/20'}`}
+                        className={`h-full transition-all duration-500 ease-out ${isLight ? 'bg-white/40' : 'bg-asi-blue/30'}`}
                         style={{ width: `${pledgedPercentage}%` }}
                     />
                 )}
-                <div
-                    className={`relative h-full rounded-full transition-all duration-500 ease-out ${isLight ? 'bg-white' : 'bg-gradient-to-r from-asi-blue to-asi-darkBlue'}`}
-                    style={{ width: `${percentage}%` }}
-                />
             </div>
             <div className="flex justify-between items-center mt-2">
                 <span className={`text-sm ${isLight ? 'text-blue-100' : 'text-slate-500'}`}>

--- a/data/projects.ts
+++ b/data/projects.ts
@@ -227,10 +227,11 @@ export const approvedProjects2025: Project[] = [
 ];
 
 export const FUNDING_RECEIVED_2025 = 23941.95;
-export const FUNDING_PLEDGED_2025 = 27894;
+// Pledged is the amount still outstanding on top of what was received.
+export const FUNDING_PLEDGED_2025 = 3952.05;
 
-export const FUNDING_RECEIVED_2026 = 5241;
-export const FUNDING_PLEDGED_2026 = 3000;
+export const FUNDING_RECEIVED_2026 = 5794.74;
+export const FUNDING_PLEDGED_2026 = 13140;
 
 export const approvedProjects2026: Project[] = [
     {


### PR DESCRIPTION
Update 2026 funding: £5,794.74 received, £13,140 pledged. Pledged now renders as a distinct segment stacked on top of the received bar (received + pledged) rather than an overlay from zero, so the additional committed-but-not-yet-received amount is visible in its own colour.

Convert FUNDING_PLEDGED_2025 to the outstanding-on-top convention (27894 -> 3952.05) to preserve that cycle's bar geometry.