### PR TITLE
Apply constitutional amendments approved at ASI UK AGM 21 June 2026

### DIFF
--- a/data/constitution.json
+++ b/data/constitution.json
@@ -1,8 +1,8 @@
 {
   "title": "ASI UK Constitution",
-  "subtitle": "Voted on 22 June, 2025 at ASI UK OGM",
-  "version": "2.0",
-  "lastUpdated": "2025-06-22",
+  "subtitle": "Voted on 21 June, 2026 at ASI UK AGM",
+  "version": "3.0",
+  "lastUpdated": "2026-06-21",
   "articles": [
     {
       "number": 1,
@@ -65,7 +65,7 @@
             },
             {
               "term": "Simple Majority",
-              "definition": "means a majority of the votes exercised by Members with Voting Rights present constituting a quorum, with each Member present and having one vote. The voting threshold must be fifty percent (50%). In the event of a tie the Chairperson shall exercise a casting vote."
+              "definition": "means a majority of the votes exercised by Members with Voting Rights present constituting a quorum, with each Member present and having one vote. The voting threshold must be fifty percent (50%) plus one."
             },
             {
               "term": "Voting Rights",


### PR DESCRIPTION
# Background
Consitutional amendments were proposed ahead of the 21 June 2026 Annual General Meeting of ASI UK. These proposed changes were sent with the agenda four weeks ahead of the meeting for members to have sufficient time to review and provide feedback.

At the meeting, no further proposed amendments were made.

The amendments are highlighted in the following document:
[ASI UK Constitution 22 June 2025 with Proposed Changed 2026.pdf](https://github.com/user-attachments/files/29183318/ASI.UK.Constitution.22.June.2025.with.Proposed.Changed.2026.pdf)

The amendment as applied in this pull request is to change the definition of "Simple Majority" to 50% **plus one**.

# Motion
The motion was made to approve the constitutional amendments as proposed and agreed in the meeting.
- Moved: Eric Welch
- Seconded: Bianna Espinal
- Discussion: None
- Vote: Unanimous

The motion to approve the constitutional amendments was carried.